### PR TITLE
Custom ImageField FileInput can be cleared now + Bugfixes

### DIFF
--- a/djpressor/__init__.py
+++ b/djpressor/__init__.py
@@ -3,4 +3,4 @@ This is a simple implementation of a fake ImageSpecField that provides
 essential functionality still used in our project but without relying on
 ImageKit.
 """
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/djpressor/static/djpressor/js/form/form-image-upload-field.js
+++ b/djpressor/static/djpressor/js/form/form-image-upload-field.js
@@ -98,11 +98,9 @@
                 $('#' + $(this).attr('id')).parent('.formField').addClass('is-floating')
 
                 // Add clear image button
-                console.log($orig_elem.attr('id'));
                 var reset_image_func = function(e){
                     e.preventDefault();
                     $orig_elem.attr('value', '');
-                    console.log('Val reset!');
                 }
 
                 var $reset_image_link = $('<a>')

--- a/djpressor/static/djpressor/js/form/form-image-upload-field.js
+++ b/djpressor/static/djpressor/js/form/form-image-upload-field.js
@@ -10,7 +10,7 @@
             // we'll just do it this way.
             this.form = $('input[data-s3-enabled="enabled"]').closest('form');
             this.formCanSubmit = true; // Initially, users can submit the form immediately
-            this.submitButton = this.form.find(':submit');  // Submit button will be disabled while upload is taking place
+            this.submitButton = this.form.find(':submit:first');  // Submit button will be disabled while upload is taking place
 
             this.original_submit_val = this.submitButton.val();
 
@@ -93,7 +93,7 @@
                     }
                 }
 
-                // CSS hack to make our special FBM form field container label not show up abover the input
+                // CSS hack to make our special FBM form field container label not show up above the input
                 $('#' + $(this).attr('id')).parent('.formField').addClass('is-floating')
             });
         },

--- a/djpressor/static/djpressor/js/form/form-image-upload-field.js
+++ b/djpressor/static/djpressor/js/form/form-image-upload-field.js
@@ -16,8 +16,9 @@
 
             this.preview_class = 'image_field_preview';  // Class that'll be given to preview box attached right after the input field.
             this.preview_box_style = {'width': '100px',
-                                      'float': 'right',
-                                      'marginTop': '-25px'}
+                                      'position': 'absolute',
+                                      'right': '0px',
+                                      'top': '0px'}
 
             // Init an empty list for uploaded images.
 
@@ -95,6 +96,23 @@
 
                 // CSS hack to make our special FBM form field container label not show up above the input
                 $('#' + $(this).attr('id')).parent('.formField').addClass('is-floating')
+
+                // Add clear image button
+                console.log($orig_elem.attr('id'));
+                var reset_image_func = function(e){
+                    e.preventDefault();
+                    $orig_elem.attr('value', '');
+                    console.log('Val reset!');
+                }
+
+                var $reset_image_link = $('<a>')
+                    .css({'display': 'block'})
+                    .attr('href', 'javascript:;').text('Clear');
+
+                $reset_image_link.bind('click', reset_image_func);
+                $file_elem.after($reset_image_link);
+
+                // TODO: Make initFileInputFields nicer!
             });
         },
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_reqs = parse_requirements('requirements.txt', session=PipSession())
 
 setup(
     name='djpressor',
-    version='0.1.1',
+    version='0.1.2',
     author='FundedByMe',
     author_email='dev@fundedbyme.com',
     maintainer='FBM',

--- a/tests/djpressor/js/form/form-image-upload-field.js
+++ b/tests/djpressor/js/form/form-image-upload-field.js
@@ -98,11 +98,9 @@
                 $('#' + $(this).attr('id')).parent('.formField').addClass('is-floating')
 
                 // Add clear image button
-                console.log($orig_elem.attr('id'));
                 var reset_image_func = function(e){
                     e.preventDefault();
                     $orig_elem.attr('value', '');
-                    console.log('Val reset!');
                 }
 
                 var $reset_image_link = $('<a>')

--- a/tests/djpressor/js/form/form-image-upload-field.js
+++ b/tests/djpressor/js/form/form-image-upload-field.js
@@ -10,14 +10,15 @@
             // we'll just do it this way.
             this.form = $('input[data-s3-enabled="enabled"]').closest('form');
             this.formCanSubmit = true; // Initially, users can submit the form immediately
-            this.submitButton = this.form.find(':submit');  // Submit button will be disabled while upload is taking place
+            this.submitButton = this.form.find(':submit:first');  // Submit button will be disabled while upload is taking place
 
             this.original_submit_val = this.submitButton.val();
 
             this.preview_class = 'image_field_preview';  // Class that'll be given to preview box attached right after the input field.
             this.preview_box_style = {'width': '100px',
-                                      'float': 'right',
-                                      'marginTop': '-25px'}
+                                      'position': 'absolute',
+                                      'right': '0px',
+                                      'top': '0px'}
 
             // Init an empty list for uploaded images.
 
@@ -93,8 +94,25 @@
                     }
                 }
 
-                // CSS hack to make our special FBM form field container label not show up abover the input
+                // CSS hack to make our special FBM form field container label not show up above the input
                 $('#' + $(this).attr('id')).parent('.formField').addClass('is-floating')
+
+                // Add clear image button
+                console.log($orig_elem.attr('id'));
+                var reset_image_func = function(e){
+                    e.preventDefault();
+                    $orig_elem.attr('value', '');
+                    console.log('Val reset!');
+                }
+
+                var $reset_image_link = $('<a>')
+                    .css({'display': 'block'})
+                    .attr('href', 'javascript:;').text('Clear');
+
+                $reset_image_link.bind('click', reset_image_func);
+                $file_elem.after($reset_image_link);
+
+                // TODO: Make initFileInputFields nicer!
             });
         },
 


### PR DESCRIPTION
- Add `Clear Image` button to field, so users can clear an image from non-required image fields.
- Fix for a form submit button handling bug where if a form has more than one submit buttons, both will end up with the same text val after uploading an image.
