### PR TITLE
Fix strange url of images if image source wrong

### DIFF
--- a/djpressor/utils.py
+++ b/djpressor/utils.py
@@ -45,7 +45,7 @@ class ImageDescriptor(object):
                 if not parsed.netloc or not parsed.path:
                     # if source field doesn't have a url in it
                     # we'll just return an empty ImageFileObject
-                    return self.imagefile
+                    return ImageFileObject()
 
                 # get original image filename
                 filename = parsed.path.split("/")[


### PR DESCRIPTION
Fix strange url of images if image source wrong

Change returning self.imagefile to new ImageFileObject() empty
object so that previous url will not be reused